### PR TITLE
Refactored Dockerfile and install script for volumes

### DIFF
--- a/base/2.4.2/Dockerfile
+++ b/base/2.4.2/Dockerfile
@@ -39,15 +39,13 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip
 
 COPY config/php.ini /usr/local/etc/php/
-COPY config/install_magento.sh install_magento.sh
+COPY config/install_magento.sh /tmp/install_magento.sh
 
 RUN if [ -x "$(command -v apache2-foreground)" ]; then a2enmod rewrite; fi
 
-ADD https://github.com/magento/magento2/archive/refs/tags/2.4.2.tar.gz magento.tar.gz
-ADD https://github.com/magento/magento2-sample-data/archive/refs/tags/2.4.2.tar.gz ../sample-data.tar.gz
+ADD https://github.com/magento/magento2/archive/refs/tags/2.4.2.tar.gz /tmp/magento.tar.gz
+ADD https://github.com/magento/magento2-sample-data/archive/refs/tags/2.4.2.tar.gz /tmp/sample-data.tar.gz
 
-RUN chmod +x install_magento.sh
+RUN chmod +x /tmp/install_magento.sh
 
-CMD ["bash", "install_magento.sh"]
-
-EXPOSE 80
+CMD ["bash", "/tmp/install_magento.sh"]

--- a/base/2.4.2/config/install_magento.sh
+++ b/base/2.4.2/config/install_magento.sh
@@ -36,7 +36,19 @@ else
 	exit 1
 fi
 
-if [[ -e ./pub/index.php ]]; then
+if [[ -e /tmp/magento.tar.gz ]]; then
+	mv /tmp/magento.tar.gz /var/www/html
+else
+	echo "Magento 2 tar is already moved to /var/www/html"
+fi
+
+if [[ -e /tmp/sample-data.tar.gz ]]; then
+	mv /tmp/sample-data.tar.gz /var/www
+else
+	echo "Magento 2 sample data tar is alread moved to /var/www"
+fi
+
+if [[ -e /var/www/html/pub/index.php ]]; then
         echo "Already extracted Magento"
 else
         tar -xf magento.tar.gz --strip-components 1


### PR DESCRIPTION
Refactored the Dockerfile and install script so that we can use persistent volumes on /var/www/html. Otherwise the install script was getting overwritten (deleted actually) and the installation was failing. Now that we have the install script and compressed Magento files in /tmp, we can then move them to /var/www/html after the container is built.